### PR TITLE
Migrate to CMake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
-# libs
-libs/
-
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 [Rr]eleases/
 x64/
 x86/
+build/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+# libs
+libs/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/wxwidgets"]
+	path = libs/wxwidgets
+	url = https://github.com/wxWidgets/wxWidgets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(Minesweeper
   MainGUI.cpp
 )
 
-target_link_libraries(Minesweeper ${wxWidgets_LIBRARIES})
+target_link_libraries(Minesweeper wx::core wx::base)
 
 install(TARGETS Minesweeper
   DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,18 +6,25 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(wxWidgets 3.0 REQUIRED COMPONENTS std stc)
+set(wxBUILD_SHARED OFF)
+set(wxBUILD_USE_STATIC_RUNTIME ON)
+
+set(wxWidgets_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libs/wxWidgets")
+set(wxWidgets_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libs/wxWidgets/lib/vc_x64_lib")
+set(wxWidgets_CONFIGURATION  "msw")
+
+find_package(wxWidgets REQUIRED COMPONENTS core base)
+if(wxWidgets_USE_FILE) # not defined in CONFIG mode
+    include(${wxWidgets_USE_FILE})
+endif()
 
 add_executable(Minesweeper
+  WIN32
   App.cpp
   MainGUI.cpp
 )
 
-target_link_libraries(Minesweeper
-  PRIVATE
-    wx::std
-    wx::stc
-)
+target_link_libraries(Minesweeper ${wxWidgets_LIBRARIES})
 
 install(TARGETS Minesweeper
   DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(wxBUILD_SHARED OFF)
-set(wxBUILD_USE_STATIC_RUNTIME ON)
-
-set(wxWidgets_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libs/wxWidgets")
-set(wxWidgets_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libs/wxWidgets/lib/vc_x64_lib")
-set(wxWidgets_CONFIGURATION  "msw")
+if (WIN32)
+  set(wxBUILD_USE_STATIC_RUNTIME ON)
+endif()
 
 add_subdirectory(libs/wxWidgets)
 add_executable(Minesweeper
-  WIN32
   App.cpp
   MainGUI.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,7 @@ set(wxWidgets_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libs/wxWidgets")
 set(wxWidgets_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libs/wxWidgets/lib/vc_x64_lib")
 set(wxWidgets_CONFIGURATION  "msw")
 
-find_package(wxWidgets REQUIRED COMPONENTS core base)
-if(wxWidgets_USE_FILE) # not defined in CONFIG mode
-    include(${wxWidgets_USE_FILE})
-endif()
-
+add_subdirectory(libs/wxWidgets)
 add_executable(Minesweeper
   WIN32
   App.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 add_subdirectory(libs/wxwidgets)
 add_executable(Minesweeper
+  WIN32
   App.cpp
   MainGUI.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if (WIN32)
   set(wxBUILD_USE_STATIC_RUNTIME ON)
 endif()
 
-add_subdirectory(libs/wxWidgets)
+add_subdirectory(libs/wxwidgets)
 add_executable(Minesweeper
   App.cpp
   MainGUI.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(Minesweeper VERSION 1.3 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(wxWidgets 3.0 REQUIRED COMPONENTS std stc)
+
+add_executable(Minesweeper
+  App.cpp
+  MainGUI.cpp
+)
+
+target_link_libraries(Minesweeper
+  PRIVATE
+    wx::std
+    wx::stc
+)
+
+install(TARGETS Minesweeper
+  DESTINATION bin
+)

--- a/README.md
+++ b/README.md
@@ -6,22 +6,29 @@ A simple, native, and cross-platform Minesweeper game made with wxWidgets.
 
 ## Installation
 
-Grab the executable appropriate to your system in the [GitHub Releases page](https://github.com/DoodlesEpic/Minesweeper/releases/) and start playing, no installation needed.
+Grab the executable appropriate for your system in the [GitHub Releases page](https://github.com/DoodlesEpic/Minesweeper/releases/) and start playing, no installation needed.
 
 ## Development
 
-This is application is developed using C++, the [Meson Build system](https://mesonbuild.com/), and [wxWidgets UI library](https://wxwidgets.org/). You must set up each one of those dependencies in your system, installation will differ for each operating system, so follow the guide on each website. The recommended compiler to use under Windows is Clang under [MSYS2](https://www.msys2.org/).
+This is application is developed using C++, the [CMake build system](https://cmake.org/), and the [wxWidgets UI library](https://wxwidgets.org/). You must set up each one of those dependencies in your system, installation will differ for each operating system, so follow the guide on each website. The recommended compiler to use under Windows is Clang under [MSYS2](https://www.msys2.org/).
+
+If you're using an Ubuntu-based distribution, you may install the needed dependencies using the following command:
+
+```sh
+sudo apt install build-essential git cmake libgtk-3-dev
+```
 
 To start development, clone the repository and run in the root folder:
 
 ```sh
-meson setup build -Dbuildtype=debugoptimized
+git submodule update --init --recursive --progress
+cmake -S . -B build -D CMAKE_BUILD_TYPE=Debug
 ```
 
-Then compile the application using:
+Compile wxWidgets and the application using:
 
 ```sh
-meson compile -C build
+cmake --build build -j8
 ```
 
 The final executable will be available under the build folder with the name Minesweeper and the appropriate file extension depending on your system.


### PR DESCRIPTION
This is currently a long-lived branch that utilizes CMake as the build system until Meson fixes the need to use wx-config even when under Windows (wx-config does not exist on Windows and thus the builds fail).